### PR TITLE
support version 2 of the applet

### DIFF
--- a/khardwarewallet/build.gradle
+++ b/khardwarewallet/build.gradle
@@ -26,7 +26,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'com.github.status-im:hardwallet-lite-android:v1.0'
+    implementation 'com.github.status-im:hardwallet-lite-android:29bf055'
 
     api "com.github.walleth.kethereum:bip39:$kethereum_version"
 

--- a/khardwarewallet/src/main/java/org/walleth/khartwarewallet/KHardwareManager.kt
+++ b/khardwarewallet/src/main/java/org/walleth/khartwarewallet/KHardwareManager.kt
@@ -65,7 +65,7 @@ class KHardwareManager : Thread(), NfcAdapter.ReaderCallback {
         try {
             val channel = KhartwareChannel(CardChannel(isoDep))
 
-            val supportedVersion = KhartwareVardVersion(1, 2)
+            val supportedVersion = KhartwareVardVersion(2, 0)
             if (channel.cardInfo.version != supportedVersion) {
                 throw(IllegalStateException("Card version not supported. is:" + channel.cardInfo.version + " expected: " + supportedVersion))
             }

--- a/khardwarewallet/src/main/java/org/walleth/khartwarewallet/KhartwareChannel.kt
+++ b/khardwarewallet/src/main/java/org/walleth/khartwarewallet/KhartwareChannel.kt
@@ -95,8 +95,7 @@ class KhartwareChannel(cardChannel: CardChannel) {
         return KhartwareStatus(
             valuesList[0].intValue,
             valuesList[1].intValue,
-            valuesList[2].intValue == 0xff,
-            valuesList[3].intValue == 0xff
+            valuesList[2].intValue == 0xff
         )
     }
 
@@ -127,7 +126,7 @@ class KhartwareChannel(cardChannel: CardChannel) {
         val chainId = tx.chain!!.id
         val encodeRLPHash = tx.encodeRLP(SignatureData().apply { v = chainId.toByte() }).keccak()
 
-        val signedTransaction = cmdSet.sign(encodeRLPHash, 1, true, true).checkOK().data
+        val signedTransaction = cmdSet.sign(encodeRLPHash).checkOK().data
 
         val parsed = blvParser.parse(signedTransaction)
 

--- a/khardwarewallet/src/main/java/org/walleth/khartwarewallet/KhartwareStatus.kt
+++ b/khardwarewallet/src/main/java/org/walleth/khartwarewallet/KhartwareStatus.kt
@@ -6,6 +6,5 @@ package org.walleth.khartwarewallet
 data class KhartwareStatus(
     val pinRetryCount: Int,
     val pukRetryCount: Int,
-    val isKeyInitialized: Boolean,
-    val isKeyDerivationSupported: Boolean
+    val isKeyInitialized: Boolean
 )


### PR DESCRIPTION
This switches support to version 2 of the applet. There have been some breaking changes, mostly in removing workarounds and tricks which were needed for a specific card we were using earlier. This has simplified the API. Version 2.0 is still WIP, but it is the best version to develop for now.